### PR TITLE
fix: error when attempting to stringify a BigInt

### DIFF
--- a/src/components/userUtils/FetchContent.tsx
+++ b/src/components/userUtils/FetchContent.tsx
@@ -8,6 +8,13 @@ import type { GetEvents } from '@helia/unixfs';
 
 const defaultTimeoutValue = 5000
 const textDecoder = new TextDecoder()
+
+// See https://github.com/GoogleChromeLabs/jsbi/issues/30
+const stringifyReplacer =
+    BigInt.prototype.toJSON === undefined
+        ? (_, v) => typeof v === 'bigint' ? v.toString() : v
+        : undefined
+
 /**
  * A collapsible section that displays the form for fetching content from IPFS.
  */
@@ -44,7 +51,7 @@ export default function FetchContent () {
       return prev
     })
     if (detail.toString() === '[object Object]') {
-      setUtilLog((prev) => [...prev, `${progEvent.type}: ${JSON.stringify(progEvent.detail)}`])
+      setUtilLog((prev) => [...prev, `${progEvent.type}: ${JSON.stringify(progEvent.detail, stringifyReplacer)}`])
       return
     }
     setUtilLog((prev) => [...prev, `${progEvent.type}: ${progEvent.detail}`])


### PR DESCRIPTION
If `toJSON` is not defined on BigInteger, a runtime error is thrown when calling `stringify`.

This occurs when trying to resolve a CID on the `Fetch Content` form.

The PR attempts to detect this condition and enable the application to work, without trying to modify the prototype.

<img width="680" alt="Screenshot 2023-11-18 at 2 59 48 PM" src="https://github.com/SgtPooki/helia-playground/assets/819940/45d80053-2cc2-4006-b91c-091030bb009c">

